### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 **This project is abandoned as I currently do not have time to work on it. Please feel free to fork it.**
 
-#EDI
+# EDI
 
 EDI is an IDE. Rather than an Integrated Development Environment it strives to be an Integrating Development Environment in the spirit of Acme. EDI does not try to do it all. It rather leans on the wonderful tools that already exist on your machine. It acts as a bridge between those commands and the editor.
 
 
-###REQUIREMENTS
+### REQUIREMENTS
 You just need [Go](http://golang.org/doc/install) and a recent browser that supports websockets. It has been tested on the latest Firefox and Chrome versions.
 Tested both on GNU/Linux and Mac. Not tested on Windows(I'm sure there are parts that will not work.)
 
 
-###INSTALLATION
+### INSTALLATION
 To install make sure you have set `$GOPATH` and `go` is in your `$PATH`. Execute
 
     sh INSTALL.sh
@@ -18,7 +18,7 @@ To install make sure you have set `$GOPATH` and `go` is in your `$PATH`. Execute
 This should build a static binary for your OS as `$GOPATH/bin/edi`.
 
 
-###USAGE
+### USAGE
 EDI runs a webserver on port 8312. Open your browser on that port. 
 The command view accepts these commands:
 - `E file_name` to open file (relative paths also allowed)
@@ -35,7 +35,7 @@ Right clicking on a file name in the command view performs what is called a cont
 You can execute many of the commands your OS provides as long as it does not require standard input or ncurses.
 
 
-###NOTES
+### NOTES
 - This is an alpha version. Things will break. I do not take responsibility of your lost code.
 - There is no customization at the moment. This will change in the next release. But for now edit the code to customize.
 - Keybindings for the editor is currently vim. This can be changed by editing `app/s/j/edi.js`. emacs, sublime-text key bindings are available.


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
